### PR TITLE
unescape to allow special chars in passwords

### DIFF
--- a/Netscaler/get-nslicexp.ps1
+++ b/Netscaler/get-nslicexp.ps1
@@ -97,7 +97,8 @@ function login-ns {
 			"username" = "$username";
 			"password" = "$password"
 		}
-	}
+	# un-escape because this causes issues with special characters	
+	}  | ForEach-Object { [System.Text.RegularExpressions.Regex]::Unescape($_) }
 	try {
 		Invoke-RestMethod -Uri "$hostname/nitro/v1/config/login" -Body $body -SessionVariable NSSession `
 			-Headers @{ "Content-Type" = "application/vnd.com.citrix.netscaler.login+json" } -Method POST | Out-Null


### PR DESCRIPTION
`convertto-json` escapes all sorts of special characters for you. This is an issue if you have these characters (like an ampersand) in your password. 
This change undoes that escaping.